### PR TITLE
refactor: type을 직접 정의한다.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": false,
+  "bracketSameLine": false,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "quoteProps": "as-needed",
+  "semi": true,
+  "trailingComma": "es5"
+}

--- a/app/bubble.tsx
+++ b/app/bubble.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 /**
  * @description
@@ -6,9 +6,9 @@
  * 이에 임시로 jsx 확장자명으로 컴포넌트를 구성합니다.
  */
 
-import BubbleUI from 'react-bubble-ui';
-import 'react-bubble-ui/dist/index.css';
-import { mbtiCombinations } from './mbti-data';
+import BubbleUI from "react-bubble-ui";
+import "react-bubble-ui/dist/index.css";
+import { mbtiCombinations } from "./mbti-data";
 
 export default function Bubble() {
   const options = {

--- a/app/bubble.tsx
+++ b/app/bubble.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 /**
  * @description
@@ -6,9 +6,9 @@
  * 이에 임시로 jsx 확장자명으로 컴포넌트를 구성합니다.
  */
 
-import BubbleUI from "react-bubble-ui";
-import "react-bubble-ui/dist/index.css";
-import { mbtiCombinations } from "./mbti-data";
+import BubbleUI from 'react-bubble-ui';
+import 'react-bubble-ui/dist/index.css';
+import { mbtiCombinations } from './mbti-data';
 
 export default function Bubble() {
   const options = {
@@ -33,7 +33,8 @@ export default function Bubble() {
           <div
             key={i}
             onClick={() => alert(`나는 ${data}!`)}
-            className="w-full h-full rounded-full flex items-center justify-center bg-[#3157DD] text-white font-semibold text-xl">
+            className="w-full h-full rounded-full flex items-center justify-center bg-[#3157DD] text-white font-semibold text-xl"
+          >
             {data}
           </div>
         );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
-import dynamic from 'next/dynamic.js';
+import dynamic from "next/dynamic.js";
 
-const Bubble = dynamic(() => import('./bubble'), { ssr: false });
+const Bubble = dynamic(() => import("./bubble"), { ssr: false });
 
 export default function Home() {
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
-import dynamic from "next/dynamic.js";
+import dynamic from 'next/dynamic.js';
 
-const Bubble = dynamic(() => import("./bubble.jsx"), { ssr: false });
+const Bubble = dynamic(() => import('./bubble'), { ssr: false });
 
 export default function Home() {
   return (

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-declare module 'react-bubble-ui' {
-  import React from 'react';
+declare module "react-bubble-ui" {
+  import React from "react";
 
   interface BubbleProps {
     options: {
@@ -20,7 +20,7 @@ declare module 'react-bubble-ui' {
     className?: string;
   }
 
-  export const BubbleUI: React.FC<BubbleProps>;
+  const BubbleUI: React.FC<BubbleProps>;
 
   export default BubbleUI;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,26 @@
+declare module 'react-bubble-ui' {
+  import React from 'react';
+
+  interface BubbleProps {
+    options: {
+      size: number;
+      minSize: number;
+      gutter: number;
+      provideProps: boolean;
+      numCols: number;
+      fringeWidth: number;
+      yRadius: number;
+      xRadius: number;
+      cornerRadius: number;
+      showGuides: boolean;
+      compact: boolean;
+      gravitation: number;
+    };
+    children: React.ReactNode;
+    className?: string;
+  }
+
+  export const BubbleUI: React.FC<BubbleProps>;
+
+  export default BubbleUI;
+}


### PR DESCRIPTION
다른 라이브러리들을 보았을 때 보통 bubble picker의 쓰임이 Native한 환경에서 하다보니 swift나 react-native에서는 많은 라이브러리들이 있었습니다.

하지만 react, next에서 사용 가능한 라이브러리들은 별로 없고 css와 dom을 직접 건드는 형태의 사례들만 보았습니다.

따라서 declare 파일을 통해 직접 라이브러리의 타입을 정의하는 쪽으로 잡아보았습니다.

그래도 해결되지 않은 문제는 브라우저 화면이다보니 Native한 환경은 못따라 가는 것이 문제네요...!